### PR TITLE
Correct browser support for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Ouroboros is an ancient symbol depicting a serpent or dragon eating its own 
 - Firefox 18+
 - IE 10+
 - Opera 12+
-- Safari 6+
+- Safari 5+
 - iOS 5 &amp; 6 (scrolling pauses animation)
 
 A standard 32x32 animated gif throbber is provided as a fallback for older versions of IE. It is centered where the spinner animation would have been.


### PR DESCRIPTION
Upon testing, Safari version 5.1.7 (6534.57.2) on OS X 10.6.8 plays the animations just fine.

For the record: I also checked with older versions of Firefox: since at least v6, it plays well save for a 1px vertical bar appearing in the middle halfway through the animation. This bar disappears only on v18.
